### PR TITLE
Fix Retries

### DIFF
--- a/cli/src/helpers/transactions.ts
+++ b/cli/src/helpers/transactions.ts
@@ -139,16 +139,16 @@ export async function sendSignedTransaction({
         "recent",
         true
       );
-      if (!confirmation) {
-        // console.log("Not confirmed, max retry hit")
-        throw new Error("Max signature retries hit")
-      }
-      if (confirmation.err) {
+      // if (!confirmation) {
+      //   // console.log("Not confirmed, max retry hit")
+      //   throw new Error("Max signature retries hit")
+      // }
+      if (confirmation && confirmation.err) {
         console.error(confirmation.err);
         throw new Error("Transaction failed: Custom instruction error");
       }
 
-      slot = confirmation?.slot || 0;
+      slot = confirmation ? confirmation.slot : 0;
     } catch (err) {
       console.error("Error caught", err);
       if ((err as any).timeout) {
@@ -238,7 +238,7 @@ async function awaitTransactionSignatureConfirmation(
     }, timeout);
 
     let numTries = 0;
-    let maxTries = 3;
+    let maxTries = 2;
     while (!done && numTries < maxTries && queryStatus) {
       // eslint-disable-next-line no-loop-func
       await (async () => {
@@ -392,8 +392,8 @@ export const sendTransactions = async (
 
       // sign each transaction in current slice
       for (let j = 0; j < currArr.length; j++) { 
-        if (signersSet[j + i].length > 0) {
-          currArr[j].partialSign(...signersSet[j + i]);
+        if (signersSet[idxMap[j] + i].length > 0) {
+          currArr[j].partialSign(...signersSet[idxMap[j] + i]);
         }
       }
 

--- a/client/src/contexts/ConnectionContext.tsx
+++ b/client/src/contexts/ConnectionContext.tsx
@@ -367,8 +367,8 @@ export const sendTransactions = async (
 
         // sign each transaction in current slice
         for (let j = 0; j < currArr.length; j++) { 
-          if (signersSet[j + i].length > 0) {
-            currArr[j].partialSign(...signersSet[j + i]);
+          if (signersSet[idxMap[j] + i].length > 0) {
+            currArr[j].partialSign(...signersSet[idxMap[j] + i]);
           }
         }
 
@@ -646,16 +646,16 @@ export async function sendSignedTransaction({
         "recent",
         true
       );
-      if (!confirmation) {
-        // // console.log("Not confirmed, max retry hit")
-        throw new Error("Max signature retries hit")
-      }
-      if (confirmation.err) {
+      // if (!confirmation) {
+      //   // // console.log("Not confirmed, max retry hit")
+      //   throw new Error("Max signature retries hit")
+      // }
+      if (confirmation && confirmation.err) {
         console.error(confirmation.err);
         throw new Error("Transaction failed: Custom instruction error");
       }
 
-      slot = confirmation?.slot || 0;
+      slot = confirmation ? confirmation.slot : 0;
     } catch (err) {
       console.error("Error caught", err);
       if ((err as any).timeout) {
@@ -753,7 +753,7 @@ async function awaitTransactionSignatureConfirmation(
     }, timeout);
 
     let numTries = 0;
-    let maxTries = 3;
+    let maxTries = 2;
     while (!done && numTries < maxTries && queryStatus) {
       // eslint-disable-next-line no-loop-func
       await (async () => {
@@ -786,6 +786,7 @@ async function awaitTransactionSignatureConfirmation(
         } catch (e) {
           if (!done) {
             // // console.log("REST connection error: txid", txid, e);
+            console.error(e)
             reject();
           }
         }


### PR DESCRIPTION
1. For each tx, don't retry blockhash on null signature confirmation (mainnet has slow tx confirmation). All successful txs on mainnet had null signature confirmations. 
2. Will keep catching errors, users can resend txs to retry if tx doesn't go through on mainnet