### PR TITLE
avoid sending tx on same color, update tooltips

### DIFF
--- a/client/src/components/Game/index.js
+++ b/client/src/components/Game/index.js
@@ -492,9 +492,6 @@ export class Game extends React.Component {
             mint: this.state.focus.mint,
             owner: this.state.focus.owner,
         });
-        notify({
-            message: "Changing color...",
-        });
     }
 
     changeColors = () => {
@@ -503,9 +500,6 @@ export class Game extends React.Component {
             spaces: this.state.selecting.poses,
             frame: this.state.colorApplyAll ? -1 : this.state.frame,
             owners: this.state.selecting.owners,
-        });
-        notify({
-            message: "Changing colors...",
         });
     }
 
@@ -566,9 +560,6 @@ export class Game extends React.Component {
                         init_y: bounds.top,
                         frame: this.state.colorApplyAll === "true" ? -1 : this.state.frame,
                         owners: this.state.selecting.owners,
-                    });
-                    notify({
-                        message: "Uploading image...",
                     });
                 }.bind(this);
 

--- a/client/src/components/Game/selecting_sidebar.js
+++ b/client/src/components/Game/selecting_sidebar.js
@@ -2,7 +2,7 @@ import React from "react";
 import "./index.css";
 import {getBounds} from './index.js';
 import { notify } from "../../utils";
-import { NEIGHBORHOOD_SIZE } from "../../constants";
+import { NEIGHBORHOOD_SIZE, TX_COST, CHANGE_COLOR_BATCH_SIZE, BUY_BATCH_SIZE } from "../../constants";
 import {
   Box,
   Button,
@@ -150,11 +150,11 @@ export class SelectingSidebar extends React.Component {
         </ListItem>
         </List>;
 
-        let tooltipModifyColorTitle = `Estimated Cost to Change Colors:  ${(this.state.ownedSelection.size * 0.000005).toFixed(6)} SOL`;
-        let tooltipSetPriceTitle = `Estimated Cost to List/Delist:  ${(this.state.ownedSelection.size * 0.000005).toFixed(6)} SOL`;
+        let tooltipModifyColorTitle = `Estimated Cost to Change Colors:  ${(this.state.ownedSelection.size * TX_COST / CHANGE_COLOR_BATCH_SIZE).toFixed(6)} SOL`;
+        let tooltipSetPriceTitle = `Estimated Cost to List/Delist:  ${(this.state.ownedSelection.size * TX_COST / CHANGE_COLOR_BATCH_SIZE).toFixed(6)} SOL`;
         let tooltipBuyTitle = `Batch buying is non-atomic and is available as a convenience feature. Successful purchase of every Space selected is not guaranteed.
         
-        Estimated Transaction Cost to Buy:  ${(this.props.selecting.purchasableInfo.length * 0.000005).toFixed(6)} SOL`;
+        Estimated Transaction Cost to Buy:  ${(this.props.selecting.purchasableInfo.length * TX_COST / BUY_BATCH_SIZE).toFixed(6)} SOL`;
         
         return (
 

--- a/client/src/constants/config.ts
+++ b/client/src/constants/config.ts
@@ -30,6 +30,9 @@ export const BASE_TRANSACTION_SIZE = 3 + 32 + 65;
 export const VOUCHER_PRICE_CONSTANT = 0.01059;
 export const VOUCHER_MAX_PRICE = 1000000;
 export const MINT_PRICE = 0.014;
+export const CHANGE_COLOR_BATCH_SIZE = 6;
+export const BUY_BATCH_SIZE = 4;
+export const TX_COST = 0.000005;
 
 export const MINT_NOT_READY_NBDS = new Set();
 export const MINT_TIME = 1645106400;

--- a/client/src/contexts/ConnectionContext.tsx
+++ b/client/src/contexts/ConnectionContext.tsx
@@ -647,7 +647,7 @@ export async function sendSignedTransaction({
         true
       );
       if (!confirmation) {
-        console.log("Not confirmed, max retry hit")
+        // console.log("Not confirmed, max retry hit")
         throw new Error("Max signature retries hit")
       }
       if (confirmation && confirmation.err) {
@@ -776,7 +776,7 @@ async function awaitTransactionSignatureConfirmation(
               done = true;
               reject(status.err);
             } else if (!status.confirmations) {
-              console.log("REST no confirmations for", txid, status);
+              // console.log("REST no confirmations for", txid, status);
             } else {
               // // console.log("REST confirmation for", txid, status);
               done = true;


### PR DESCRIPTION
1. Only send txs when the changed color is different from the original
2. Update tooltips with correct fees
3. Remove logging in connection context